### PR TITLE
Changes for Sentinel 65X

### DIFF
--- a/fpga/project/vera-sentinel.def
+++ b/fpga/project/vera-sentinel.def
@@ -1,8 +1,6 @@
 
 PROJECT_TYPE := nextpnr-ice40
 
-PROJECT_DEFINES := WITH_EXTBUS_SYNC
-
 PROJECT_NEXTPNR_OPTS := --package sg48 --up5k
 PROJECT_YOSYS_OPTS := -abc9 -dsp
 

--- a/fpga/project/vera-sentinel.pcf
+++ b/fpga/project/vera-sentinel.pcf
@@ -1,17 +1,15 @@
 
-set_frequency sysclk 25.0
-set_frequency extbus_clk 8.0
+set_io extbus_sysclk 35
+set_frequency extbus_sysclk 25.0
 
-set_io extbus_rw 40
-set_io extbus_clk 37
 set_io extbus_cs_n 41
-
+set_io extbus_phi2 37
+set_io extbus_rw 40
 set_io extbus_a[0] 36
 set_io extbus_a[1] 43
 set_io extbus_a[2] 38
 set_io extbus_a[3] 42
 set_io extbus_a[4] 39
-
 set_io extbus_d[0] 23
 set_io extbus_d[1] 25
 set_io extbus_d[2] 26
@@ -20,9 +18,7 @@ set_io extbus_d[4] 28
 set_io extbus_d[5] 31
 set_io extbus_d[6] 32
 set_io extbus_d[7] 34
-
 set_io extbus_irq_n 3
-
 set_io vga_r[0] 6
 set_io vga_r[1] 9
 set_io vga_r[2] 10
@@ -35,15 +31,12 @@ set_io vga_b[0] 46
 set_io vga_b[1] 47
 set_io vga_b[2] 44
 set_io vga_b[3] 48
-set_io vga_hsync 19
-set_io vga_vsync 18
-
-set_io sysclk 35
+set_io vga_hsync 18
+set_io vga_vsync 19
+set_io spi_sck 15
+set_io spi_mosi 17
+set_io spi_miso 14
+set_io spi_ssel_n_sd 16
 set_io audio_lrck 45
 set_io audio_bck 2
 set_io audio_data 4
-
-#set_io spi_sck 15
-#set_io spi_mosi 17
-#set_io spi_miso 14
-#set_io spi_ssel_n_sd 16

--- a/fpga/source/compat/sentinel_top.v
+++ b/fpga/source/compat/sentinel_top.v
@@ -1,7 +1,6 @@
+`define WITH_SENTINEL
 
 module sentinel_top(
-    input  wire       sysclk,
-
     // VGA interface
     output wire [3:0] vga_r,
     output wire [3:0] vga_g,
@@ -15,16 +14,17 @@ module sentinel_top(
     output wire       audio_data,
 
     // External bus interface
-    input  wire       extbus_clk,    /* Clock */
+    input  wire       extbus_sysclk,    /* Clock */
     input  wire       extbus_cs_n,   /* Chip Select */
-    input  wire       extbus_rw,     /* Read(H)/Write(L) Select */
+    input  wire       extbus_phi2,     /* PHI2 clock */
+    input  wire       extbus_rw,     /* Read/Write Strobe */
     input  wire [4:0] extbus_a,      /* Address */
     inout  wire [7:0] extbus_d,      /* Data (bi-directional) */
     output wire       extbus_irq_n   /* IRQ */
 );
 
 top vera(
-    .clk25(sysclk),
+    .clk25(extbus_sysclk),
 
     .vga_r(vga_r),
     .vga_g(vga_g),
@@ -42,11 +42,11 @@ top vera(
     .spi_ssel_n_sd(),
 
     .extbus_cs_n(extbus_cs_n),
-    .extbus_rd_n(~extbus_rw),
-    .extbus_wr_n(extbus_rw),
+	.extbus_phi2(extbus_phi2),
+    .extbus_rw(extbus_rw),
     .extbus_a(extbus_a),
     .extbus_d(extbus_d),
     .extbus_irq_n(extbus_irq_n)
-    );
+);
 
 endmodule

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -39,8 +39,13 @@ module top(
 
     // External bus interface
     input  wire       extbus_cs_n,   /* Chip select */
+`ifdef WITH_SENTINEL
+    input  wire       extbus_phi2,   /* PHI2 clock */
+    input  wire       extbus_rw,   	 /* Read/Write strobe */
+`else
     input  wire       extbus_rd_n,   /* Read strobe */
     input  wire       extbus_wr_n,   /* Write strobe */
+`endif
     input  wire [4:0] extbus_a,      /* Address */
     inout  wire [7:0] extbus_d,      /* Data (bi-directional) */
     output wire       extbus_irq_n   /* IRQ */
@@ -215,8 +220,13 @@ module top(
         5'h1F: rddata = {spi_busy, 4'b0, spi_autotx_r, spi_slow_r, spi_select_r};
     endcase
 
+`ifdef WITH_SENTINEL
+    wire bus_read  = !extbus_cs_n && extbus_phi2 &&  extbus_rw;
+    wire bus_write = !extbus_cs_n && extbus_phi2 && !extbus_rw;
+`else
     wire bus_read  = !extbus_cs_n &&  extbus_wr_n && !extbus_rd_n;
     wire bus_write = !extbus_cs_n && !extbus_wr_n;
+`endif
     assign extbus_d = bus_read ? rddata : 8'bZ;
 
     wire [3:0] irq_enable = {irq_enable_audio_fifo_low_r, irq_enable_sprite_collision_r, irq_enable_line_r, irq_enable_vsync_r};


### PR DESCRIPTION
This PR alters the Sentinel target to use PHI2 and R/W instead of /RD and /WR to interface to the 65816 bus. It is tested and working on the Upduino V3 plugged into Sentinel 65X prototype 4. 